### PR TITLE
add ssl config options to the plugin

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -24,6 +24,21 @@ form:
         0: Disabled
       validate:
         type: bool
+    enablessl:
+      type: toggle
+      label: Enable SSL
+      highlight: 1
+      default: 1
+      options:
+        1: Enabled
+        0: Disabled
+      validate:
+        type: bool
+    certpath:
+      type: text
+      label: 'Path to SSL Cert (cafile)'
+      placeholder: default
+      help: 'Leave blank, if not known'
     twitter:
       type: section
       title: Twitter config

--- a/src/Manager/PostManager.php
+++ b/src/Manager/PostManager.php
@@ -180,7 +180,21 @@ class PostManager
      */
     private function downloadFile($url, $basename, $dir)
     {
-        $fileContents = @file_get_contents($url);
+    	$arrContextOptions = [];
+
+    	$config = $this->grav['config']->get('plugins.social-feed');
+
+        if (isset($config['enablessl']) && $config['enablessl'] == false) {
+        	$arrContextOptions['ssl']['verify_peer'] = 0;
+        	$arrContextOptions['ssl']['verify_peer_name'] = 0;
+        }
+
+        if (isset($config['certpath']) && $config['certpath']) {
+        	$arrContextOptions['ssl']['cafile'] = $config['certpath'];
+        }
+        print_r($arrContextOptions);
+
+        $fileContents = @file_get_contents($url, false, stream_context_create($arrContextOptions));
         if (!$fileContents || strstr($fileContents, '<!DOCTYPE html>')) {
             return;
         }

--- a/src/Manager/PostManager.php
+++ b/src/Manager/PostManager.php
@@ -180,17 +180,16 @@ class PostManager
      */
     private function downloadFile($url, $basename, $dir)
     {
-    	$arrContextOptions = [];
+        $arrContextOptions = [];
 
-    	$config = $this->grav['config']->get('plugins.social-feed');
-
+        $config = $this->grav['config']->get('plugins.social-feed');
         if (isset($config['enablessl']) && $config['enablessl'] == false) {
-        	$arrContextOptions['ssl']['verify_peer'] = 0;
-        	$arrContextOptions['ssl']['verify_peer_name'] = 0;
+            $arrContextOptions['ssl']['verify_peer'] = 0;
+            $arrContextOptions['ssl']['verify_peer_name'] = 0;
         }
 
         if (isset($config['certpath']) && $config['certpath']) {
-        	$arrContextOptions['ssl']['cafile'] = $config['certpath'];
+            $arrContextOptions['ssl']['cafile'] = $config['certpath'];
         }
 
         $fileContents = @file_get_contents($url, false, stream_context_create($arrContextOptions));

--- a/src/Manager/PostManager.php
+++ b/src/Manager/PostManager.php
@@ -192,12 +192,12 @@ class PostManager
         if (isset($config['certpath']) && $config['certpath']) {
         	$arrContextOptions['ssl']['cafile'] = $config['certpath'];
         }
-        print_r($arrContextOptions);
 
         $fileContents = @file_get_contents($url, false, stream_context_create($arrContextOptions));
         if (!$fileContents || strstr($fileContents, '<!DOCTYPE html>')) {
             return;
         }
+        
         $storageFile = tempnam(sys_get_temp_dir(), 'SocialFeed');
         file_put_contents($storageFile, $fileContents);
         $finfo = finfo_open(FILEINFO_MIME_TYPE);


### PR DESCRIPTION
Possibility to define the path to the ssl cert for downloading images with file_get_contents
Add the option to switch of the ssl validation for downloading images (should only be used for test purposes)