### PR TITLE
Declare grav variable in socialfeedcommand as static variable

### DIFF
--- a/cli/SocialFeedCommand.php
+++ b/cli/SocialFeedCommand.php
@@ -15,6 +15,8 @@ use Grav\Plugin\SocialFeed\Manager\PostManager;
  */
 class SocialFeedCommand extends ConsoleCommand
 {
+    static $grav;
+
     public function __construct($name = null)
     {
         parent::__construct($name);


### PR DESCRIPTION
This fix the problem: https://github.com/moduleon/grav-plugin-social-feed/issues/17

Also, it would be possible to use this instead of using self, but I think this is the better solution. What do you think?